### PR TITLE
working fix for GDC-hosted hg38 BAMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It also requires a credential file called `credentials.json` within the same pat
 
 First edit the `config.json`:
 - `credential_path`: the credential file for NCI Data Commons, The default would be "./credentials.json"
-- `gdc_data_host`: We will need send http request to here in order to get corresponding url for given BAM. For legacy bams the path should be "https://api.gdc.cancer.gov/legacy/files/".
+- `gdc_data_host`: We will need send http request to here in order to get corresponding url for given BAM. For legacy (hg19) bams the path should be "https://api.gdc.cancer.gov/legacy/files/"; for hg38 the path should be "https://api.gdc.cancer.gov/files/".
 - Please leave `user_project` empty for now.
 
 Next set our default active user project and `gcloud auth login` with your user account.

--- a/buddy.py
+++ b/buddy.py
@@ -3,13 +3,9 @@ from flask import Flask, request
 from signedbam import signedbam
 from threading import Lock
 import requests
-<<<<<<< hg38
 from urllib.parse import urlparse, parse_qs
 from time import time
-
-=======
 import dateutil.parser
->>>>>>> master
 
 app = Flask(__name__)
 
@@ -21,17 +17,12 @@ class URLHandler:
         with self.lock:
             if uuid in self.cache:
                 bam, bai = self.cache[uuid]
-<<<<<<< hg38
-                time_expires = min(int(parse_qs(urlparse(bai).query)['X-Amz-Expires'][0]), int(parse_qs(urlparse(bam).query)['X-Amz-Expires'][0]))
-                print(parse_qs(urlparse(bai).query))
-=======
+                # time_expires = min(int(parse_qs(urlparse(bai).query)['X-Amz-Expires'][0]), int(parse_qs(urlparse(bam).query)['X-Amz-Expires'][0]))
                 # print(parse_qs(urlparse(bai).query))
                 time_expires = min(
                     int(dateutil.parser.isoparse(parse_qs(urlparse(bai).query)['x-goog-date'][0]).timestamp()), 
                     int(dateutil.parser.isoparse(parse_qs(urlparse(bam).query)['x-goog-date'][0]).timestamp())
-                    )
-                from time import time
->>>>>>> master
+                )
                 if time_expires - time() > 5 * 60:
                     return bam, bai
             bam, bai = signedbam(uuid)

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
     "credential_path":"credentials.json",
     "user_project": "",
-    "gdc_data_host": "https://api.gdc.cancer.gov/legacy/files/" 
+    "gdc_data_host": "https://api.gdc.cancer.gov/files/" 
 }

--- a/config.json
+++ b/config.json
@@ -1,10 +1,5 @@
 {
     "credential_path": "credentials_igv.json",
     "user_project": "",
-<<<<<<< hg38
-    "gdc_data_host": "https://api.gdc.cancer.gov/files/" 
+    "gdc_data_host": "https://api.gdc.cancer.gov/files/"
 }
-=======
-    "gdc_data_host": "https://api.gdc.cancer.gov/legacy/files/"
-}
->>>>>>> master


### PR DESCRIPTION
WIP:
- Determine where BAMs are hosted (Google or AWS or Az)
- Cleaner UI for genome builds
- parse from different fields by Google (`Expires`) / AWS hosted BAMs (`X-Amz-Expires`)